### PR TITLE
Fix AsyncRead and AsyncWrite implementations

### DIFF
--- a/src/sftp.rs
+++ b/src/sftp.rs
@@ -205,7 +205,7 @@ impl AsyncRead for File {
     ) -> Poll<io::Result<usize>> {
         self.stream
             .clone()
-            .with(|_s| self.inner.read(buf))
+            .read_with(|_s| self.inner.read(buf))
             .boxed()
             .poll_unpin(cx)
     }
@@ -219,7 +219,7 @@ impl AsyncWrite for File {
     ) -> Poll<Result<usize, io::Error>> {
         self.stream
             .clone()
-            .with(|_s| self.inner.write(buf))
+            .write_with(|_s| self.inner.write(buf))
             .boxed()
             .poll_unpin(cx)
     }
@@ -227,7 +227,7 @@ impl AsyncWrite for File {
     fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), io::Error>> {
         self.stream
             .clone()
-            .with(|_s| self.inner.flush())
+            .write_with(|_s| self.inner.flush())
             .boxed()
             .poll_unpin(cx)
     }


### PR DESCRIPTION
A couple of fixes to do with the implementations of `AsyncRead` and `AsyncWrite`:
 - Switch from `with()` to `read_with()`/`write_with()`. This stops the read operations being woken up when the write becomes unblocked and vice versa.
 - Implement `poll_close()` for `Channel`. This needs to call the underlying `close()` method on the `ssh2::Channel` otherwise the channel is never closed.