### PR TITLE
Expose session `trace` function and associated bitflags, to allow libssh2 tracing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ edition = "2018"
 vendored-openssl = ["ssh2/vendored-openssl"]
 
 [dependencies]
-ssh2 = "0.9"
+ssh2 = "0.9.1"
 libssh2-sys = "0.2"
 async-io = "^1.3"
 futures = "0.3.8"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,5 @@ pub use sftp::{File, Sftp};
 pub use ssh2::{
     BlockDirections, ExitSignal, FileStat, FileType, Host, KnownHostFileKind, KnownHosts,
     OpenFlags, Prompt, PtyModes, PublicKey, ReadWindow, RenameFlags, ScpFileStat, WriteWindow, 
-    // This needs PR#209 on ssh2-rs (https://github.com/alexcrichton/ssh2-rs/pull/209)
-    // TraceFlags
+    TraceFlags
 };

--- a/src/session.rs
+++ b/src/session.rs
@@ -390,11 +390,10 @@ impl Session {
         self.inner.block_directions()
     }
 
-/* This needs PR#209 on ssh2-rs (https://github.com/alexcrichton/ssh2-rs/pull/209)
     /// See [`trace`](ssh2::Session::trace).
     pub fn trace(&self, bitmask: ssh2::TraceFlags) {
         self.inner.trace(bitmask);
-    }*/
+    }
 }
 
 #[cfg(unix)]


### PR DESCRIPTION
libssh2 has a libssh2_trace function which allows setting a bitmask enabling or disabling debug output.

This has been exposed in ssh2-rs - see alexcrichton/ssh2-rs#209.

This PR wraps the related function and re-exports the bitflags.