### PR TITLE
Derive `clone` for `Session`

### DIFF
--- a/src/session.rs
+++ b/src/session.rs
@@ -18,6 +18,7 @@ use std::{
 };
 
 /// See [`Session`](ssh2::Session).
+#[derive(Clone)]
 pub struct Session {
     inner: ssh2::Session,
     stream: Option<Arc<Async<TcpStream>>>,


### PR DESCRIPTION
ssh2-rs allows `Session` structs to be cloned, but async-ssh2 currently does not (even though it is easily derived as all fields can be cloned). 

This is useful in an async context - for example, I wanted to be able to spawn a separate task that would send keepalives, cloning the session allowed that, because I could move the clone of the session into the async block that I was spawning.
